### PR TITLE
fix(SNTPlaceHolder): fix incorrect usage of minime token type

### DIFF
--- a/contracts/SNTPlaceHolder.sol
+++ b/contracts/SNTPlaceHolder.sol
@@ -60,12 +60,12 @@ contract SNTPlaceHolder is TokenController, Ownable2Step {
     function onApprove(address, address, uint256) public pure override returns (bool) {
         return true;
     }
-    
+
     /// @notice This method can be used by the controller to extract mistakenly
     ///  sent tokens to this contract.
     /// @param _token The address of the token contract that you want to recover
     ///  set to 0 in case you want to extract ether.
-    function claimTokens(MiniMeToken _token) public onlyOwner {
+    function claimTokens(MiniMeBase _token) public onlyOwner {
         if (address(_token) == address(0)) {
             payable(owner).transfer(address(this).balance);
             return;


### PR DESCRIPTION
The `SNTPlaceholder` uses `MiniMeToken` type in a function even though only `MiniMeBase` is actually imported.

This commit fixes the function signature so that the code can actually compile.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
