### PR TITLE
refactor: use custom error type instead of error strings

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,1 +1,7 @@
-OptmismMintableMiniMeTokenTest:testDeployment() (gas: 56870)
+BurnTest:testDeployment() (gas: 56874)
+BurnTest:test_Burn() (gas: 124436)
+BurnTest:test_RevertWhen_SenderIsNotBridge() (gas: 10076)
+MintTest:testDeployment() (gas: 56874)
+MintTest:test_Mint() (gas: 110237)
+MintTest:test_RevertWhen_SenderIsNotBridge() (gas: 10076)
+OptmismMintableMiniMeTokenTest:testDeployment() (gas: 56874)

--- a/contracts/optimism/OptimismMintableMiniMeToken.sol
+++ b/contracts/optimism/OptimismMintableMiniMeToken.sol
@@ -13,6 +13,9 @@ import { Semver } from "./Semver.sol";
 ///         Designed to be backwards compatible with the older StandardL2ERC20 token which was only
 ///         meant for use on L2.
 contract OptimismMintableMiniMeToken is IOptimismMintableERC20, ILegacyMintableERC20, MiniMeBase, Semver {
+    /// @notice Error that is thrown if the sender is not the bridge.
+    error OptimismMintableMiniMeToken_SenderNotBridge();
+
     /// @notice Address of the corresponding version of this token on the remote chain.
     address public immutable REMOTE_TOKEN;
 
@@ -31,7 +34,7 @@ contract OptimismMintableMiniMeToken is IOptimismMintableERC20, ILegacyMintableE
 
     /// @notice A modifier that only allows the bridge to call
     modifier onlyBridge() {
-        require(msg.sender == BRIDGE, "OptimismMintableMiniMeToken: only bridge can mint and burn");
+        if (msg.sender != BRIDGE) revert OptimismMintableMiniMeToken_SenderNotBridge();
         _;
     }
 


### PR DESCRIPTION
The `onlyBridge` modifier uses strings as error messages which are expensive in gas.

This commit refactors this to use a custom error type instead and also introduces some basic tests to ensure the errors are emitted properly.

It also adds some sanity tests for minting and burning bridge tokens.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added natspec comments?
- [x] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
