### PR TITLE
Fix comments, improve claimTokens

### DIFF
--- a/contracts/SNTOptimismController.sol
+++ b/contracts/SNTOptimismController.sol
@@ -5,66 +5,57 @@ import { TokenController } from "@vacp2p/minime/contracts/TokenController.sol";
 import { MiniMeBase } from "@vacp2p/minime/contracts/MiniMeBase.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 
-/*
-    Copyright 2017, Jordi Baylina
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * @title SNTOptimismController
+ *  @author Ricardo Guilherme Schmidt, r4bbit
+ *  @dev Contract for keeping the SNT token in Optimism.
+ *  It does nothing, but can be replaced by other contract that does something.
  */
-
-/// @title SNTPlaceholder Contract
-/// @author Jordi Baylina
-/// @dev The SNTPlaceholder contract will take control over the SNT after the contribution
-///  is finalized and before the Status Network is deployed.
-///  The contract allows for SNT transfers and transferFrom and implements the
-///  logic for transferring control of the token to the network when the offering
-///  asks it to do so.
 contract SNTOptimismController is TokenController, Ownable2Step {
     MiniMeBase public snt;
 
+    /**
+     * @param _snt The address of the SNT token
+     */
     constructor(address payable _snt) {
         snt = MiniMeBase(_snt);
     }
 
-    /// @notice The owner of this contract can change the controller of the SNT token
-    ///  Please, be sure that the owner is a trusted agent or 0x0 address.
-    /// @param _newController The address of the new controller
+    /**
+     * @notice The owner of this contract can change the controller of the SNT token
+     *  Please, be sure that the owner is a trusted agent or 0x0 address.
+     * @param _newController The address of the new controller
+     */
     function changeController(address payable _newController) public onlyOwner {
         snt.changeController(_newController);
         emit ControllerChanged(_newController);
     }
 
-    //////////
-    // MiniMe Controller Interface functions
-    //////////
-
-    // In between the offering and the network. Default settings for allowing token transfers.
+    /**
+     * @dev proxyPayment set to reject all Ether.
+     */
     function proxyPayment(address) public payable override returns (bool) {
         return false;
     }
 
+    /**
+     * @dev onTransfer set to accept any transfer
+     */
     function onTransfer(address, address, uint256) public pure override returns (bool) {
         return true;
     }
 
+    /**
+     * @dev onApprove set to accept any approval
+     */
     function onApprove(address, address, uint256) public pure override returns (bool) {
         return true;
     }
 
-    /// @notice This method can be used by the controller to extract mistakenly
-    ///  sent tokens to this contract.
-    /// @param _token The address of the token contract that you want to recover
-    ///  set to 0 in case you want to extract ether.
+    /**
+     * @notice Extract mistakenly sent tokens to this contract.
+     * @param _token Token contract to recover, 0 to extract ether.
+     */
     function claimTokens(MiniMeBase _token) public onlyOwner {
         if (address(_token) == address(0)) {
             payable(owner()).transfer(address(this).balance);

--- a/contracts/SNTOptimismController.sol
+++ b/contracts/SNTOptimismController.sol
@@ -53,18 +53,20 @@ contract SNTOptimismController is TokenController, Ownable2Step {
     }
 
     /**
-     * @notice Extract mistakenly sent tokens to this contract.
+     * @notice Send tokens or ether from this contract to owner.
      * @param _token Token contract to recover, 0 to extract ether.
      */
     function claimTokens(MiniMeBase _token) public onlyOwner {
+        uint256 balance;
         if (address(_token) == address(0)) {
-            payable(owner()).transfer(address(this).balance);
+            balance = address(this).balance;
+            payable(msg.sender).transfer(balance);
             return;
+        } else {
+            balance = _token.balanceOf(address(this));
+            _token.transfer(msg.sender, balance);
         }
-
-        uint256 balance = _token.balanceOf(address(this));
-        _token.transfer(owner(), balance);
-        emit ClaimedTokens(address(_token), owner(), balance);
+        emit ClaimedTokens(address(_token), msg.sender, balance);
     }
 
     event ClaimedTokens(address indexed _token, address indexed _controller, uint256 _amount);


### PR DESCRIPTION
## Description
Remove junk comments, improve context of comments & natspec.
Improve claimTokens: use msg.sender instead of owner() in a onlyOwner function; Emit event for extracted ether.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
