### PR TITLE
fix(DeplopyBridge): change token symbol so it matches L1 token symbol

### DIFF
--- a/script/DeploymentConfig.s.sol
+++ b/script/DeploymentConfig.s.sol
@@ -71,7 +71,7 @@ contract DeploymentConfig is Script {
             parentSnapShotBlock: 0,
             tokenName: "Status Test Token",
             decimals: 18,
-            tokenSymbol: "SNT",
+            tokenSymbol: "STT",
             transferEnabled: true
         });
     }


### PR DESCRIPTION
This is so that deployment on goerli optimism matches L1 goerli token symbol